### PR TITLE
add  file extension support to Cpp

### DIFF
--- a/src/com/romanenco/gitt/syntax/SyntaxHelper.java
+++ b/src/com/romanenco/gitt/syntax/SyntaxHelper.java
@@ -72,7 +72,7 @@ public class SyntaxHelper {
 		{Bash, "bash", "sh"},
 		{CSharp,"cs"},
 		{ColdFusion},
-		{Cpp, "m", "h", "cpp", "c"},
+		{Cpp, "m", "h", "cpp", "c", "cc", "hpp"},
 		{Css, "css"},
 		{Delphi, "pas"},
 		{Diff, "diff"},


### PR DESCRIPTION
mpp is used for C++ template  files
cc is equal to cpp and is also frequently used, Google LevelDB for example
